### PR TITLE
github-actions: Artifact actions v3 brownouts by January 30th, 2025

### DIFF
--- a/.github/workflows/code-cover-gen.yaml
+++ b/.github/workflows/code-cover-gen.yaml
@@ -65,7 +65,7 @@ jobs:
           ${RUNNER_TEMP}/pr-codecov-run-tests.sh artifacts/cover-${PR}-${BASE_SHA}.json "${CHANGED_PKGS}"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: cover
           path: artifacts/cover-*.json


### PR DESCRIPTION
https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/#artifact-actions-v3-brownouts